### PR TITLE
CMD replaced with ENTRYPOINT to make passing flags easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian
 COPY . /src
 
 RUN apt-get update \
-  && apt-get install -y curl make git mercurial \ 
+  && apt-get install -y curl make git mercurial \
   && cd /src \
   && make \
   && apt-get purge -y curl make git mercurial \
@@ -13,4 +13,4 @@ RUN apt-get update \
 
 EXPOSE 9126
 
-CMD ["/src/newrelic_exporter"]
+ENTRYPOINT ["/src/newrelic_exporter"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requires a New Relic account.
 
 ### Running in a container
 
-	docker run jfindley/newrelic-exporter
+	docker run jfindley/newrelic-exporter --api.key=********
 
 ### From source
 


### PR DESCRIPTION
Example: 

``` bash
docker run -d -p 9126:9126 jfindley/newrelic-exporter --api.key=*****
```
